### PR TITLE
Add runtime requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,7 @@ transformers==4.19.2
 webdataset==0.2.5
 open-clip-torch==2.7.0
 gradio==3.11
+kornia==0.6
+invisible-watermark>=0.1.5
+streamlit-drawable-canvas==0.8.0
 -e .


### PR DESCRIPTION
Simply copies `kornia`, `streamlit-drawable-canvas`, and `invisible-watermark` from the conda-style `environment.yaml` to the pip-style `requirements.txt`.

Tested with the following:

```
    git clone https://github.com/Stability-AI/stablediffusion/
    cd stablediffusion
    python -m venv venv
    source venv/bin/activate
    pip install -U pip
    pip install -r requirements.txt
    python scripts/txt2img.py --prompt "our galaxy itself contains a hundred billion stars" --ckpt ../768-v-ema.ckpt --config configs/stable-diffusion/v2-inference-v.yaml --H 768 --W 768  --n_samples 1
```
on Ubuntu 22 with Python 3.8, or similar, on a machine with CUDA already installed.
