### PR TITLE
Change batch defaults to 1 to be friendlier to lower VRAM cards (x768 model)

### DIFF
--- a/scripts/img2img.py
+++ b/scripts/img2img.py
@@ -126,7 +126,7 @@ def main():
     parser.add_argument(
         "--n_samples",
         type=int,
-        default=2,
+        default=1,
         help="how many samples to produce for each given prompt. A.k.a batch size",
     )
 

--- a/scripts/txt2img.py
+++ b/scripts/txt2img.py
@@ -91,7 +91,7 @@ def parse_args():
     parser.add_argument(
         "--n_iter",
         type=int,
-        default=3,
+        default=2,
         help="sample this often",
     )
     parser.add_argument(
@@ -121,7 +121,7 @@ def parse_args():
     parser.add_argument(
         "--n_samples",
         type=int,
-        default=3,
+        default=1,
         help="how many samples to produce for each given prompt. A.k.a batch size",
     )
     parser.add_argument(


### PR DESCRIPTION
## Problem
![image](https://user-images.githubusercontent.com/2738686/203757908-3bf4f13d-cc71-4cbb-ad7a-b2b749191077.png)

Getting OOM memory errors at the decode stage with baseline arguments from the readme, specifying only `--ckpt "..." --prompt "..." --config "..." --H 768 --W 768`

Even with a Medium VRAM card (3080 Ti, 12GB) and Xformers installed. the default batch sizes will overflow vram at a size of 3 for the 768x768 model. This means the sample commands from the readme won't work unless one digs through the command-line args manually and notices the defaults.

## Proposed PR
* This PR simply changes the defaults for img2img and txt2img to have batch sizes of 1, and in the case of txt2img the n_iter size to 2. This is a simple quality of life change that should help people get what they expect easier.
* txt2img: Leaves n_iter at 2 so you still get a nice grid of 2 samples, but with batch size 1.

## Example command
`python scripts/txt2img.py --prompt "a beautiful painting of an astronaut riding a unicorn" --ckpt 768-v-ema.ckpt --config configs/stable-diffusion/v2-inference-v.yaml --H 768 --W 768`

## System info
* Windows 10 21H2
* torch 1.12.1+cu116
* xformers installed and working
* cuda_11.6.r11.6/compiler.31057947_0