### PR TITLE
Switch from no_grad to inference_mode for scripts

### DIFF
--- a/scripts/gradio/depth2img.py
+++ b/scripts/gradio/depth2img.py
@@ -64,8 +64,7 @@ def paint(sampler, image, prompt, t_enc, seed, scale, num_samples=1, callback=No
     wm_encoder = WatermarkEncoder()
     wm_encoder.set_watermark('bytes', wm.encode('utf-8'))
 
-    with torch.no_grad(),\
-            torch.autocast("cuda"):
+    with torch.inference_mode(), torch.autocast("cuda"):
         batch = make_batch_sd(
             image, txt=prompt, device=device, num_samples=num_samples)
         z = model.get_first_stage_encoding(model.encode_first_stage(

--- a/scripts/gradio/inpainting.py
+++ b/scripts/gradio/inpainting.py
@@ -81,8 +81,7 @@ def inpaint(sampler, image, mask, prompt, seed, scale, ddim_steps, num_samples=1
     start_code = torch.from_numpy(start_code).to(
         device=device, dtype=torch.float32)
 
-    with torch.no_grad(), \
-            torch.autocast("cuda"):
+    with torch.inference_mode(), torch.autocast("cuda"):
         batch = make_batch_sd(image, mask, txt=prompt,
                               device=device, num_samples=num_samples)
 

--- a/scripts/img2img.py
+++ b/scripts/img2img.py
@@ -230,7 +230,8 @@ def main():
     print(f"target t_enc is {t_enc} steps")
 
     precision_scope = autocast if opt.precision == "autocast" else nullcontext
-    with torch.no_grad():
+    
+    with torch.inference_mode():
         with precision_scope("cuda"):
             with model.ema_scope():
                 all_samples = list()

--- a/scripts/streamlit/depth2img.py
+++ b/scripts/streamlit/depth2img.py
@@ -61,8 +61,7 @@ def paint(sampler, image, prompt, t_enc, seed, scale, num_samples=1, callback=No
     wm_encoder = WatermarkEncoder()
     wm_encoder.set_watermark('bytes', wm.encode('utf-8'))
 
-    with torch.no_grad(),\
-            torch.autocast("cuda"):
+    with torch.inference_mode(), torch.autocast("cuda"):
         batch = make_batch_sd(image, txt=prompt, device=device, num_samples=num_samples)
         z = model.get_first_stage_encoding(model.encode_first_stage(batch[model.first_stage_key]))  # move to latent space
         c = model.cond_stage_model.encode(batch["txt"])

--- a/scripts/streamlit/inpainting.py
+++ b/scripts/streamlit/inpainting.py
@@ -79,8 +79,7 @@ def inpaint(sampler, image, mask, prompt, seed, scale, ddim_steps, num_samples=1
     start_code = prng.randn(num_samples, 4, h // 8, w // 8)
     start_code = torch.from_numpy(start_code).to(device=device, dtype=torch.float32)
 
-    with torch.no_grad(), \
-            torch.autocast("cuda"):
+    with torch.inference_mode(), torch.autocast("cuda"):
             batch = make_batch_sd(image, mask, txt=prompt, device=device, num_samples=num_samples)
 
             c = model.cond_stage_model.encode(batch["txt"])

--- a/scripts/streamlit/superresolution.py
+++ b/scripts/streamlit/superresolution.py
@@ -64,8 +64,8 @@ def paint(sampler, image, prompt, seed, scale, h, w, steps, num_samples=1, callb
     wm = "SDV2"
     wm_encoder = WatermarkEncoder()
     wm_encoder.set_watermark('bytes', wm.encode('utf-8'))
-    with torch.no_grad(),\
-            torch.autocast("cuda"):
+    
+    with torch.inference_mode(), torch.autocast("cuda"):
         batch = make_batch_sd(image, txt=prompt, device=device, num_samples=num_samples)
         c = model.cond_stage_model.encode(batch["txt"])
         c_cat = list()
@@ -105,8 +105,10 @@ def paint(sampler, image, prompt, seed, scale, h, w, steps, num_samples=1, callb
             x_T=start_code,
             callback=callback
         )
-    with torch.no_grad():
+    
+    with torch.inference_mode():
         x_samples_ddim = model.decode_first_stage(samples)
+    
     result = torch.clamp((x_samples_ddim + 1.0) / 2.0, min=0.0, max=1.0)
     result = result.cpu().numpy().transpose(0, 2, 3, 1) * 255
     st.text(f"upscaled image shape: {result.shape}")

--- a/scripts/txt2img.py
+++ b/scripts/txt2img.py
@@ -232,9 +232,8 @@ def main(opt):
         start_code = torch.randn([opt.n_samples, opt.C, opt.H // opt.f, opt.W // opt.f], device=device)
 
     precision_scope = autocast if opt.precision == "autocast" else nullcontext
-    with torch.no_grad(), \
-        precision_scope("cuda"), \
-        model.ema_scope():
+    
+    with torch.inference_mode(), precision_scope("cuda"), model.ema_scope():
             all_samples = list()
             for n in trange(opt.n_iter, desc="Sampling"):
                 for prompts in tqdm(data, desc="data"):


### PR DESCRIPTION
## Problem

torch.no_grad() is a slightly older API, pytorch advocates newer api for inference and future changes.

## Proposed PR
* [torch.inference_mode()](https://pytorch.org/docs/stable/generated/torch.inference_mode.html) is a newer method which also disables grad, tracking, and a few other things for slightly better performance and is a transparent change.
* This pr sweeps the scripts/ dir and replaces the no_grad() calls with inference_mode() context manager instead.
* This is the advocated method in performance docs and by [Pytorch themselves](https://twitter.com/pytorch/status/1437838231505096708). The performance gain here for this model is negligible but it's best practice and more idiomatic for inference.

## Testing Method
* Main test: simple command repeatedly on main and dev branch `python -m scripts.txt2img --prompt "a beautiful painting of an astronaut riding a horse" --ckpt /path/to/512-base-ema.ckpt --W 512 --H 512 --n_iter 4 --n_sample 2`
* The results are effectively identical within margin of error. Showing possibly an extremely tiny gain over time for the diffusion process though not always. Likely perf noise.

### Before-After
![before_after](https://user-images.githubusercontent.com/2738686/203767385-e06732ba-b17b-40fc-a456-2c42ed661dac.png)

## System info
* Windows 10 21H2
* torch 1.12.1+cu116
* xformers installed and working
* cuda_11.6.r11.6/compiler.31057947_0