### PR TITLE
Use create_model directly

### DIFF
--- a/ldm/modules/encoders/modules.py
+++ b/ldm/modules/encoders/modules.py
@@ -144,9 +144,8 @@ class FrozenOpenCLIPEmbedder(AbstractEncoder):
                  freeze=True, layer="last"):
         super().__init__()
         assert layer in self.LAYERS
-        model, _, _ = open_clip.create_model_and_transforms(arch, device=torch.device('cpu'), pretrained=version)
-        del model.visual
-        self.model = model
+        self.model = open_clip.create_model(arch, device=torch.device('cpu'), pretrained=version)
+        del self.model.visual
 
         self.device = device
         self.max_length = max_length


### PR DESCRIPTION
For `FrozenOpenCLIPEmbedder`, `open_clip.create_model_and_transforms()` simply calls `create_model()` with the same arguments.

https://github.com/mlfoundations/open_clip/blob/9d31b2ec4df6d8228f370ff20c8267ec6ba39383/src/open_clip/factory.py#L201

We can skip the unnecessary step.