### PR TITLE
remove wrong arguments while using from_file.

### DIFF
--- a/scripts/txt2img.py
+++ b/scripts/txt2img.py
@@ -165,12 +165,6 @@ def parse_args():
         choices=["full", "autocast"],
         default="autocast"
     )
-    parser.add_argument(
-        "--repeat",
-        type=int,
-        default=1,
-        help="repeat each prompt in file this often",
-    )
     opt = parser.parse_args()
     return opt
 
@@ -218,7 +212,7 @@ def main(opt):
         print(f"reading prompts from {opt.from_file}")
         with open(opt.from_file, "r") as f:
             data = f.read().splitlines()
-            data = [p for p in data for i in range(opt.repeat)]
+            data = [p for p in data for i in range(batch_size)]
             data = list(chunk(data, batch_size))
 
     sample_path = os.path.join(outpath, "samples")


### PR DESCRIPTION
when running txt2img.py, the argument "--repeat", `data = [p for p in data for i in range(opt.repeat)]` should be `data = [p for p in data for i in range(batch_size)]`, since we want the prompt to repeat exactly "batch_size: times, to be wrapped up with chunk() function. Otherwise, the shape issue will come up later on.