### PR TITLE
Using Metal Performance Shaders (Apple M1) instead of CUDA (proof of concept)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,22 @@ cd ../stablediffusion
 Upon successful installation, the code will automatically default to [memory efficient attention](https://github.com/facebookresearch/xformers)
 for the self- and cross-attention layers in the U-Net and autoencoder.
 
+## macOS installation
+
+Instead of PyTorch 1.12.1, use the latest version of Pytorch (>=1.13) - which supports [Metal Performance Shaders](https://developer.apple.com/metal/pytorch/).
+
+```commandline
+pip install torch torchvision
+pip install transformers==4.19.2 diffusers invisible-watermark
+pip install -e .
+```
+
+Most likely `xformers` will not work, as it only supports CUDA.
+
+When running `txt2img.py` or `img2img.py`, add `--precision=full --n_samples=1 --n_iter=1` commandline arguments.
+
+Tested on a M1 Max Macbook pro with 32GB RAM. 32 GB RAM is probably the minimum for 768x768 images.
+
 ## General Disclaimer
 Stable Diffusion models are general text-to-image diffusion models and therefore mirror biases and (mis-)conceptions that are present
 in their training data. Although efforts were made to reduce the inclusion of explicit pornographic material, **we do not recommend using the provided weights for services or products without additional safety mechanisms and considerations.

--- a/configs/stable-diffusion/v2-inference-v.yaml
+++ b/configs/stable-diffusion/v2-inference-v.yaml
@@ -22,7 +22,7 @@ model:
       target: ldm.modules.diffusionmodules.openaimodel.UNetModel
       params:
         use_checkpoint: True
-        use_fp16: True
+        use_fp16: False
         image_size: 32 # unused
         in_channels: 4
         out_channels: 4

--- a/configs/stable-diffusion/v2-inference.yaml
+++ b/configs/stable-diffusion/v2-inference.yaml
@@ -21,7 +21,7 @@ model:
       target: ldm.modules.diffusionmodules.openaimodel.UNetModel
       params:
         use_checkpoint: True
-        use_fp16: True
+        use_fp16: False
         image_size: 32 # unused
         in_channels: 4
         out_channels: 4

--- a/ldm/models/diffusion/ddim.py
+++ b/ldm/models/diffusion/ddim.py
@@ -16,8 +16,8 @@ class DDIMSampler(object):
 
     def register_buffer(self, name, attr):
         if type(attr) == torch.Tensor:
-            if attr.device != torch.device("cuda"):
-                attr = attr.to(torch.device("cuda"))
+            if attr.device != torch.device("mps"):
+                attr = attr.to(torch.device("mps"), dtype=torch.float32)
         setattr(self, name, attr)
 
     def make_schedule(self, ddim_num_steps, ddim_discretize="uniform", ddim_eta=0., verbose=True):

--- a/ldm/modules/encoders/modules.py
+++ b/ldm/modules/encoders/modules.py
@@ -42,7 +42,7 @@ class ClassEmbedder(nn.Module):
         c = self.embedding(c)
         return c
 
-    def get_unconditional_conditioning(self, bs, device="cuda"):
+    def get_unconditional_conditioning(self, bs, device="mps"):
         uc_class = self.n_classes - 1  # 1000 classes --> 0 ... 999, one extra class for ucg (class 1000)
         uc = torch.ones((bs,), device=device) * uc_class
         uc = {self.key: uc}
@@ -57,7 +57,7 @@ def disabled_train(self, mode=True):
 
 class FrozenT5Embedder(AbstractEncoder):
     """Uses the T5 transformer encoder for text"""
-    def __init__(self, version="google/t5-v1_1-large", device="cuda", max_length=77, freeze=True):  # others are google/t5-v1_1-xl and google/t5-v1_1-xxl
+    def __init__(self, version="google/t5-v1_1-large", device="mps", max_length=77, freeze=True):  # others are google/t5-v1_1-xl and google/t5-v1_1-xxl
         super().__init__()
         self.tokenizer = T5Tokenizer.from_pretrained(version)
         self.transformer = T5EncoderModel.from_pretrained(version)
@@ -92,7 +92,7 @@ class FrozenCLIPEmbedder(AbstractEncoder):
         "pooled",
         "hidden"
     ]
-    def __init__(self, version="openai/clip-vit-large-patch14", device="cuda", max_length=77,
+    def __init__(self, version="openai/clip-vit-large-patch14", device="mps", max_length=77,
                  freeze=True, layer="last", layer_idx=None):  # clip-vit-base-patch32
         super().__init__()
         assert layer in self.LAYERS
@@ -140,7 +140,7 @@ class FrozenOpenCLIPEmbedder(AbstractEncoder):
         "last",
         "penultimate"
     ]
-    def __init__(self, arch="ViT-H-14", version="laion2b_s32b_b79k", device="cuda", max_length=77,
+    def __init__(self, arch="ViT-H-14", version="laion2b_s32b_b79k", device="mps", max_length=77,
                  freeze=True, layer="last"):
         super().__init__()
         assert layer in self.LAYERS
@@ -194,7 +194,7 @@ class FrozenOpenCLIPEmbedder(AbstractEncoder):
 
 
 class FrozenCLIPT5Encoder(AbstractEncoder):
-    def __init__(self, clip_version="openai/clip-vit-large-patch14", t5_version="google/t5-v1_1-xl", device="cuda",
+    def __init__(self, clip_version="openai/clip-vit-large-patch14", t5_version="google/t5-v1_1-xl", device="mps",
                  clip_max_length=77, t5_max_length=77):
         super().__init__()
         self.clip_encoder = FrozenCLIPEmbedder(clip_version, device, max_length=clip_max_length)

--- a/scripts/img2img.py
+++ b/scripts/img2img.py
@@ -41,7 +41,7 @@ def load_model_from_config(config, ckpt, verbose=False):
         print("unexpected keys:")
         print(u)
 
-    model.cuda()
+    model.to("mps")
     model.eval()
     return model
 

--- a/scripts/txt2img.py
+++ b/scripts/txt2img.py
@@ -40,7 +40,7 @@ def load_model_from_config(config, ckpt, verbose=False):
         print("unexpected keys:")
         print(u)
 
-    model.cuda()
+    model.to("mps")
     model.eval()
     return model
 
@@ -189,7 +189,7 @@ def main(opt):
     config = OmegaConf.load(f"{opt.config}")
     model = load_model_from_config(config, f"{opt.ckpt}")
 
-    device = torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")
+    device = torch.device("cuda") if torch.cuda.is_available() else torch.device("mps")
     model = model.to(device)
 
     if opt.plms:


### PR DESCRIPTION
I've created a quick and dirty proof of concept to run Stable Diffusion `img2img` on Apple M1 GPUs, this works well on an Macbook Pro with M1 Max and 32GB RAM.
The changes are very trivial, so leaving this here for anyone who would like try Stable Diffusion on Apple hardware (or include M1 support in any forks).

If there's interest, I can convert this into a proper PR, to select which device to use (`cuda`, `mps` or even `cpu`).