### PR TITLE
fix: web ui cannot recognize the finetune_ Keys parameter when use sd20 model

### DIFF
--- a/configs/stable-diffusion/v2-inpainting-inference.yaml
+++ b/configs/stable-diffusion/v2-inpainting-inference.yaml
@@ -15,7 +15,6 @@ model:
     conditioning_key: hybrid
     scale_factor: 0.18215
     monitor: val/loss_simple_ema
-    finetune_keys: null
     use_ema: False
 
     unet_config:


### PR DESCRIPTION
## Problem description
when I using the latest branch's stable-diffusion-webui ，try to load stable-diffusion-2-inpainting model，error occurred while starting the project：
```
Loading config from: /root/stable-diffusion-webui/models/Stable-diffusion/512-inpainting-ema.yamlTraceback (most recent call last):
  File "webui.py", line 191, in <module>
    webui()
  File "webui.py", line 131, in webui
    initialize()
  File "webui.py", line 61, in initialize
    modules.sd_models.load_model()
  File "/root/stable-diffusion-webui/modules/sd_models.py", line 260, in load_model
    sd_model = instantiate_from_config(sd_config.model)
  File "/root/stable-diffusion-webui/repositories/stable-diffusion-stability-ai/ldm/util.py", line 79, in instantiate_from_config
    return get_obj_from_str(config["target"])(**config.get("params", dict()))
  File "/root/stable-diffusion-webui/modules/sd_hijack_inpainting.py", line 315, in __init__    super().__init__(*args, **kwargs)
  File "/root/stable-diffusion-webui/repositories/stable-diffusion-stability-ai/ldm/models/diffusion/ddpm.py", line 550, in __init__
    super().__init__(conditioning_key=conditioning_key, *args, **kwargs)
TypeError: __init__() got an unexpected keyword argument 'finetune_keys'
```
## My Solution
I deleted the `finetune_keys` parameter，then restart project. it works for me. 

I'm not sure if other people have this problem. I hope to discuss it with yours.

