### PR TITLE
Fix SpatialTransformer proj_out in attention.py

### DIFF
--- a/ldm/modules/attention.py
+++ b/ldm/modules/attention.py
@@ -315,7 +315,7 @@ class SpatialTransformer(nn.Module):
                                                   stride=1,
                                                   padding=0))
         else:
-            self.proj_out = zero_module(nn.Linear(in_channels, inner_dim))
+            self.proj_out = zero_module(nn.Linear(inner_dim, in_channels))
         self.use_linear = use_linear
 
     def forward(self, x, context=None):


### PR DESCRIPTION
small bug: in SpatialTransformer, when proj_out use Linear the channels should be from inner_dim to in_channels