### PR TITLE
Add CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -42,3 +42,6 @@ input:
 output:
   - format: PDF
     url: https://arxiv.org/pdf/2112.10752.pdf
+eprint: 2112.10752
+archivePrefix: arXiv
+primaryClass: cs.CV

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,44 @@
+cff-version: 1.2.0
+message: If you use this software, please cite it using these metadata.
+title: High-Resolution Image Synthesis with Latent Diffusion Models
+authors:
+  - family-names: Rombach
+    given-names: Robin
+  - family-names: Blattmann
+    given-names: Andreas
+  - family-names: Lorenz
+    given-names: Dominik
+  - family-names: Esser
+    given-names: Patrick
+  - family-names: Ommer
+    given-names: Björn
+year: 2021
+doi: 10.48550/arXiv.2112.10752
+abstract: |
+  By decomposing the image formation process into a sequential application of denoising
+  autoencoders, diffusion models (DMs) achieve state-of-the-art synthesis results on
+  image data and beyond. Additionally, their formulation allows for a guiding mechanism
+  to control the image generation process without retraining. However, since these
+  models typically operate directly in pixel space, optimization of powerful DMs often
+  consumes hundreds of GPU days and inference is expensive due to sequential
+  evaluations. To enable DM training on limited computational resources while retaining
+  their quality and flexibility, we apply them in the latent space of powerful
+  pretrained autoencoders. In contrast to previous work, training diffusion models on
+  such a representation allows for the first time to reach a near-optimal point between
+  complexity reduction and detail preservation, greatly boosting visual fidelity.
+  By introducing cross-attention layers into the model architecture, we turn diffusion
+  models into powerful and flexible generators for general conditioning inputs such as
+  text or bounding boxes and high-resolution synthesis becomes possible in a
+  convolutional manner. Our latent diffusion models (LDMs) achieve a new state of the
+  art for image inpainting and highly competitive performance on various tasks,
+  including unconditional image generation, semantic scene synthesis, and
+  super-resolution, while significantly reducing computational requirements compared to
+  pixel-based DMs.
+input:
+  - format: arXiv
+    id: 2112.10752
+    type: article
+    url: https://arxiv.org/abs/2112.10752
+output:
+  - format: PDF
+    url: https://arxiv.org/pdf/2112.10752.pdf

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,6 +1,6 @@
 cff-version: 1.2.0
 message: If you use this software, please cite it using these metadata.
-title: High-Resolution Image Synthesis with Latent Diffusion Models
+title: stablediffusion
 authors:
   - family-names: Rombach
     given-names: Robin
@@ -42,6 +42,22 @@ input:
 output:
   - format: PDF
     url: https://arxiv.org/pdf/2112.10752.pdf
-eprint: 2112.10752
-archivePrefix: arXiv
-primaryClass: cs.CV
+preferred-citation:
+  type: article
+  authors:
+    - family-names: Rombach
+      given-names: Robin
+    - family-names: Blattmann
+      given-names: Andreas
+    - family-names: Lorenz
+      given-names: Dominik
+    - family-names: Esser
+      given-names: Patrick
+    - family-names: Ommer
+      given-names: Björn
+  doi: "10.48550/arXiv.2112.10752"
+  eprint: "2112.10752"
+  archivePrefix: arXiv
+  primaryClass: cs.CV
+  title: High-Resolution Image Synthesis with Latent Diffusion Models
+  year: 2021


### PR DESCRIPTION
I add CITATION.cff so that GitHub support a citation banner on the left tab. The downside is that the following data is not exist on the generated bib tex;

```bib
      eprint={2112.10752},
      archivePrefix={arXiv},
      primaryClass={cs.CV}
```

Here is the complete bib:

```bib
@article{Rombach_High-Resolution_Image_Synthesis_2021,
  author = {Rombach, Robin and Blattmann, Andreas and Lorenz, Dominik and Esser, Patrick and Ommer, Björn},
  doi    = {10.48550/arXiv.2112.10752},
  title  = {{High-Resolution Image Synthesis with Latent Diffusion Models}},
  year   = {2021}
}
```
This is the generated citation:

Rombach, R., Blattmann, A., Lorenz, D., Esser, P., & Ommer, B. (2021). High-Resolution Image Synthesis with Latent Diffusion Models. https://doi.org/10.48550/arXiv.2112.10752