### PR TITLE
Setting default device as cuda

### DIFF
--- a/scripts/txt2img.py
+++ b/scripts/txt2img.py
@@ -182,7 +182,7 @@ def parse_args():
         type=str,
         help="Device on which Stable Diffusion will be run",
         choices=["cpu", "cuda"],
-        default="cpu"
+        default="cuda"
     )
     parser.add_argument(
         "--torchscript",


### PR DESCRIPTION
Recently there was a change to support CPU, [but CPU was set as default device](https://github.com/Stability-AI/stablediffusion/pull/147/files#diff-048b7bba4049f97b2038502af5686b6c5f53a882ff02771fcb0d733d22a0ab6cR180-R186).
It broke old versions pipelines to generate samples on `txt2image`, throwing an error:
```RuntimeError: expected scalar type BFloat16 but found Float``` 
Like in this issue https://github.com/Stability-AI/stablediffusion/issues/236.
It is solved by passing `--device cuda`, which used to be default. 

This PR changes default device to cuda.