### PR TITLE
use pytorch built-in SiLU function to save GPU memory usage

### DIFF
--- a/ldm/modules/diffusionmodules/model.py
+++ b/ldm/modules/diffusionmodules/model.py
@@ -5,6 +5,7 @@ import torch.nn as nn
 import numpy as np
 from einops import rearrange
 from typing import Optional, Any
+import torch.nn.functional as F
 
 from ldm.modules.attention import MemoryEfficientCrossAttention
 
@@ -40,7 +41,7 @@ def get_timestep_embedding(timesteps, embedding_dim):
 
 def nonlinearity(x):
     # swish
-    return x*torch.sigmoid(x)
+    return F.silu(x)
 
 
 def Normalize(in_channels, num_groups=32):


### PR DESCRIPTION
- Replaced the custom implemented `nonlinearity` function with the PyTorch built-in function `SiLU`. 
- The built-in function saves significant GPU memory when specifying a large output size. 
- According to [PyTorch documentation](https://pytorch.org/docs/1.12/generated/torch.nn.functional.silu.html?highlight=silu#torch.nn.functional.silu), the formulation/result is identical.

On my 12GB GPU card, the following command gives a GPU OOM error without this PR while runs through with it.

    python3 scripts/txt2img.py --H 1024 --W 1024 --plms --ckpt /data/models/SD/v2-1_512-ema-pruned.ckpt --config configs/stable-diffusion/v2-inference.yaml  --device cuda --prompt "pytorch logo" --n_sample 1  --n_iter 1

Tested under the default environment requirements. `SiLU` function has been available in PyTorch after 1.7.0.

