### PR TITLE
'alphas_prev' of the DDIM sampler should start with 1. 

### DIFF
--- a/ldm/modules/diffusionmodules/util.py
+++ b/ldm/modules/diffusionmodules/util.py
@@ -70,7 +70,9 @@ def make_ddim_timesteps(ddim_discr_method, num_ddim_timesteps, num_ddpm_timestep
 def make_ddim_sampling_parameters(alphacums, ddim_timesteps, eta, verbose=True):
     # select alphas for computing the variance schedule
     alphas = alphacums[ddim_timesteps]
-    alphas_prev = np.asarray([alphacums[0]] + alphacums[ddim_timesteps[:-1]].tolist())
+
+    # alphas_prev should start with 1.
+    alphas_prev = np.append(1., alphas[:-1])
 
     # according the the formula provided in https://arxiv.org/abs/2010.02502
     sigmas = eta * np.sqrt((1 - alphas_prev) / (1 - alphas) * (1 - alphas / alphas_prev))


### PR DESCRIPTION
'alphas_prev' of the DDIM sampler here should start with 1. In the original implementation, 'alpha_prev' starts with 'alphacums[0]', which is close to but not 1.. and is not theoretically correct. 'alphacums_prev[0]' is 1. instead. 

This will lead to noisy outputs of the diffusion model. I understand it has limited influence to the LDM framework, since generated latent variables are not directly visible. But I believe the model perform better if modified.