### PR TITLE
Fix: typo in 'Requirements' section: Change "recommended" to "recommend"

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ pip install -e .
 ``` 
 #### xformers efficient attention
 For more efficiency and speed on GPUs, 
-we highly recommended installing the [xformers](https://github.com/facebookresearch/xformers)
+we highly recommend installing the [xformers](https://github.com/facebookresearch/xformers)
 library.
 
 Tested on A100 with CUDA 11.4.


### PR DESCRIPTION
The word "recommended" in the 'Requirements' section should be "recommend" to maintain correct grammar and clarity in the sentence. 

- Before: "For more efficiency and speed on GPUs, we highly recommended installing the xformers library."
- After:  "For more efficiency and speed on GPUs, we highly recommend installing the xformers library."

This change ensures that the verb form agrees with the subject "we," improving the readability and accuracy of the documentation.